### PR TITLE
fix: use less `math: always` option by default

### DIFF
--- a/packages/craco-less/src/index.js
+++ b/packages/craco-less/src/index.js
@@ -8,7 +8,7 @@ const CracoLessPlugin = require("craco-less");
 const path = require("path");
 
 const overrideWebpackConfig = ({ context, pluginOptions, webpackConfig }) => {
-  pluginOptions = pluginOptions || {};
+  pluginOptions = {lessLoaderOptions: { lessOptions: { math: 'always' } }, ...pluginOptions};
 
   // add alias to theme.config
   webpackConfig.resolve.alias["../../theme.config$"] = path.join(


### PR DESCRIPTION
Co-authored-by:  Keno Moenck (@kenomo)

The problem is very well explained here by @kenomo: https://github.com/Semantic-Org/Semantic-UI-LESS/issues/74#issuecomment-872125971

> `craco-less` version 1.18.0 now depends on `"less": "^4.1.1"` instead of `3.x`. According to [lesscss](https://lesscss.org/usage/) some math options changed by default, e.g., "in order to cause fewer conflicts with CSS, which now liberally uses the / symbol between values, there is now a math mode that only requires parentheses for division. (This is now the default in Less 4.)".
> 
> To keep `semantic-ui-less` running again, the math option has to be changed back to `always`

This PR sets [Less' Math option](https://lesscss.org/usage/#less-options-math) to `always` at @semantic-ui-react/@craco-less` plugin level to prevent all the users from applying the fix manually in their webpack/craco config files.