### PR TITLE
css-patch: Bugfix for `run` no longer `async`

### DIFF
--- a/packages/css-patch/src/index.js
+++ b/packages/css-patch/src/index.js
@@ -45,7 +45,7 @@ const fixFiles = (filesToPatch, packageName) => {
   console.log(logSymbols.info, `Patch was successfully applied`);
 }
 
-const run = () => {
+const run = async () => {
   const lessPackage = hasPackages(["semantic-ui-less", "fomantic-ui-less"]);
   if (lessPackage !== undefined) {
     console.log(logSymbols.info, `Detected "${lessPackage}" package...`);


### PR DESCRIPTION
The recent release seems to have broken other packages:

```
> react-searchkit@2.0.1 postinstall /opt/invenio/var/instance/assets/node_modules/react-searchkit
> semantic-ui-css-patch
ℹ No supported packages found
/opt/invenio/var/instance/assets/node_modules/@semantic-ui-react/css-patch/dist-node/index.bin.js:21
run(process.argv).catch(function (error) {
                 ^
TypeError: Cannot read property 'catch' of undefined
    at Object.<anonymous> (/opt/invenio/var/instance/assets/node_modules/@semantic-ui-react/css-patch/dist-node/index.bin.js:21:18)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
    at internal/main/run_main_module.js:17:47

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! react-searchkit@2.0.1 postinstall: `semantic-ui-css-patch`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the react-searchkit@2.0.1 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2022-08-03T15_31_22_236Z-debug.log
RuntimeError: Process exited with code 1
```

This makes `run` `async` again