### PR TITLE
CSS-patch: Fix path for fomantic-ui-css

### DIFF
--- a/packages/css-patch/src/index.js
+++ b/packages/css-patch/src/index.js
@@ -71,17 +71,17 @@ const run = async () => {
     console.log(logSymbols.info, `Detected "${cssPackage}" package...`);
 
     const filesToPatchPath = [
-      path.resolve(nodeModulesPath, "semantic-ui-css", "semantic.css"),
-      path.resolve(nodeModulesPath, "semantic-ui-css", "semantic.min.css"),
+      path.resolve(nodeModulesPath, cssPackage, "semantic.css"),
+      path.resolve(nodeModulesPath, cssPackage, "semantic.min.css"),
       path.resolve(
         nodeModulesPath,
-        "semantic-ui-css",
+        cssPackage,
         "components",
         "step.css"
       ),
       path.resolve(
         nodeModulesPath,
-        "semantic-ui-css",
+        cssPackage,
         "components",
         "step.min.css"
       )


### PR DESCRIPTION
Fomantic-ui-css package has been correctly detected but failed due to hardcoded package name.    

![Screenshot 2022-08-17 at 12 37 06](https://user-images.githubusercontent.com/2320282/185098647-7e48b1fa-a9e3-4ce3-8e76-0a620060c634.png)
  

